### PR TITLE
change models to directly consume a "space" object intsead of an "env…

### DIFF
--- a/edge/agent/q_learner.py
+++ b/edge/agent/q_learner.py
@@ -25,7 +25,7 @@ class QLearner(Agent):
         :param keep_seed_in_data: whether to keep the seed data in the GP dataset. Should be True, otherwise GPyTorch
             fails.
         """
-        Q_model = GPQLearning(env, step_size, discount_rate,
+        Q_model = GPQLearning(env.stateaction_space, step_size, discount_rate,
                               x_seed=x_seed, y_seed=y_seed,
                               gp_params=gp_params)
         super(QLearner, self).__init__(env, Q_model)
@@ -112,7 +112,7 @@ class ConstrainedQLearner(Agent):
         :param keep_seed_in_data: whether to keep the seed data in the GP dataset. Should be True, otherwise GPyTorch
             fails.
         """
-        Q_model = GPQLearning(env, step_size, discount_rate,
+        Q_model = GPQLearning(env.stateaction_space, step_size, discount_rate,
                               x_seed=x_seed, y_seed=y_seed,
                               gp_params=gp_params)
         super(ConstrainedQLearner, self).__init__(env, Q_model)
@@ -144,7 +144,7 @@ class ConstrainedQLearner(Agent):
         self.constrained_value_policy.greed = new_greed
 
     def get_next_action(self):
-        all_actions = self.Q_model.env.action_space[:].reshape(-1, 1)
+        all_actions = self.Q_model.space.action_space[:].reshape(-1, 1)
         action_is_viable = np.array([
             self.safety_measure.measure(self.state, a) > self.safety_threshold
             for a in all_actions
@@ -205,7 +205,7 @@ class DiscreteQLearner(Agent):
             that is at the exact boundary of the viability kernel still fails due to rounding errors. Hence, this should
             be a small, positive value.
         """
-        Q_model = QLearning(env, step_size, discount_rate)
+        Q_model = QLearning(env.stateaction_space, step_size, discount_rate)
 
         super(DiscreteQLearner, self).__init__(env, Q_model)
 
@@ -244,7 +244,7 @@ class DiscreteQLearner(Agent):
     def get_next_action(self):
         q_values = self.Q_model[self.state, :]
         if self.is_constrained:
-            all_actions = self.Q_model.env.action_space[:].reshape(-1, 1)
+            all_actions = self.Q_model.space.action_space[:].reshape(-1, 1)
             action_is_viable = np.array([
                 self.constraint.measure(self.state, a) > self.safety_threshold
                 for a in all_actions

--- a/edge/agent/safety_learner.py
+++ b/edge/agent/safety_learner.py
@@ -24,7 +24,7 @@ class SafetyLearner(Agent):
         :param keep_seed_in_data: whether to keep the seed data in the GP dataset. Should be True, otherwise GPyTorch
             fails.
         """
-        safety_model = MaternSafety(env, gamma_optimistic,
+        safety_model = MaternSafety(env.stateaction_space, gamma_optimistic,
                                     x_seed, y_seed, gp_params)
         super(SafetyLearner, self).__init__(env, safety_model)
 

--- a/edge/agent/value_and_safety_learner.py
+++ b/edge/agent/value_and_safety_learner.py
@@ -36,10 +36,10 @@ class ValueAndSafetyLearner(Agent):
         :param keep_seed_in_data: whether to keep the seed data in the GPs datasets. Should be True, otherwise GPyTorch
             fails.
         """
-        Q_model = GPQLearning(env, step_size, discount_rate,
+        Q_model = GPQLearning(env.stateaction_space, step_size, discount_rate,
                               x_seed=q_x_seed, y_seed=q_y_seed,
                               gp_params=q_gp_params)
-        safety_model = MaternSafety(env, gamma_optimistic,
+        safety_model = MaternSafety(env.stateaction_space, gamma_optimistic,
                                     x_seed=s_x_seed, y_seed=s_y_seed,
                                     gp_params=s_gp_params)
         super(ValueAndSafetyLearner, self).__init__(env, Q_model, safety_model)

--- a/edge/graphics/subplotter/q_value_subplotter.py
+++ b/edge/graphics/subplotter/q_value_subplotter.py
@@ -9,9 +9,9 @@ class QValueSubplotter(Subplotter):
     def __init__(self, agent, colors, write_values=False, vmin=None, vmax=None):
         super(QValueSubplotter, self).__init__(colors)
         self.agent = agent
-        self.states = squeeze(self.model.env.state_space[:])
-        self.actions = squeeze(self.model.env.action_space[:])
-        stateaction_grid = self.model.env.stateaction_space[:, :]
+        self.states = squeeze(self.model.space.state_space[:])
+        self.actions = squeeze(self.model.space.action_space[:])
+        stateaction_grid = self.model.space[:, :]
         self.states_grid = stateaction_grid[:, :, 0]
         self.actions_grid = stateaction_grid[:, :, 1]
         self.write_values = write_values
@@ -79,9 +79,9 @@ class DiscreteQValueSubplotter(Subplotter):
                  interp_n=100):
         super(DiscreteQValueSubplotter, self).__init__(colors)
         self.agent = agent
-        self.states = squeeze(self.model.env.state_space[:])
-        self.actions = squeeze(self.model.env.action_space[:])
-        stateaction_grid = self.model.env.stateaction_space[:, :]
+        self.states = squeeze(self.model.space.state_space[:])
+        self.actions = squeeze(self.model.space.action_space[:])
+        stateaction_grid = self.model.space[:, :]
         self.states_grid = stateaction_grid[:, :, 0]
         self.actions_grid = stateaction_grid[:, :, 1]
         self.write_values = write_values

--- a/edge/graphics/subplotter/safety_subplotters.py
+++ b/edge/graphics/subplotter/safety_subplotters.py
@@ -9,8 +9,8 @@ class SafetyMeasureSubplotter(Subplotter):
     def __init__(self, agent, colors, fill=True, plot_optimistic=True):
         super(SafetyMeasureSubplotter, self).__init__(colors)
         self.agent = agent
-        self.states = squeeze(self.model.env.state_space[:])
-        self.actions = squeeze(self.model.env.action_space[:])
+        self.states = squeeze(self.model.space.state_space[:])
+        self.actions = squeeze(self.model.space.action_space[:])
 
         if not len(self.states.shape) == 1:
             raise ValueError('Too many state dimensions for plotting: '
@@ -24,7 +24,7 @@ class SafetyMeasureSubplotter(Subplotter):
         self.nS = self.states.shape[0]
         self.nA = self.actions.shape[0]
 
-        stateaction_grid = self.model.env.stateaction_space[:, :]
+        stateaction_grid = self.model.space[:, :]
         self.states_grid = stateaction_grid[:, :, 0]
         self.actions_grid = stateaction_grid[:, :, 1]
 
@@ -158,7 +158,7 @@ class SafetyGPSubplotter(Subplotter):
     def __init__(self, agent, colors):
         super(SafetyGPSubplotter, self).__init__(colors)
         self.agent = agent
-        stateaction_grid = self.agent.safety_model.env.stateaction_space[:, :]
+        stateaction_grid = self.agent.safety_model.space[:, :]
         self.states_grid = stateaction_grid[:, :, 0]
         self.actions_grid = stateaction_grid[:, :, 1]
 

--- a/edge/model/models.py
+++ b/edge/model/models.py
@@ -9,11 +9,11 @@ class Model:
     through the indexing syntax (model[i0,..., iN]), where the indexing should be thought of as if it were done on the
     StateActionSpace directly.
     """
-    def __init__(self, env):
+    def __init__(self, space):
         """
-        :param env: the environment
+        :param space: the space the model lives in.
         """
-        self.env = env
+        self.space = space
 
     def update(self):
         """ Abstract method
@@ -64,13 +64,13 @@ class DiscreteModel(Model):
         :return: a tuple that can index a np.ndarray. The tuple has d items, and each item is the list of indexes
             on the given dimension
         """
-        stateactions = self.env.stateaction_space[index].reshape(
-            (-1, self.env.stateaction_space.data_length)
+        stateactions = self.space[index].reshape(
+            (-1, self.space.data_length)
         )
         if stateactions.ndim == 1:
             stateactions = np.atleast_2d(stateactions).tolist()
         index = np.array(list(map(
-            self.env.stateaction_space.get_index_of,
+            self.space.get_index_of,
             stateactions
         )))
         # `index` is now a list of n indexes, each of length d (index.shape = (n,d))
@@ -86,8 +86,8 @@ class ContinuousModel(Model):
         :param index: tuple: the index
         :return: np.ndarray of stateactions
         """
-        return self.env.stateaction_space[index].reshape(
-            (-1, self.env.stateaction_space.data_length)
+        return self.space[index].reshape(
+            (-1, self.space.data_length)
         )
 
 
@@ -95,14 +95,14 @@ class GPModel(ContinuousModel):
     GP_SAVE_NAME = 'gp.pth'  # name of file containing the GP when saving
     SAVE_NAME = 'model.json'  # name of file containing the Model's metadata when saving
 
-    def __init__(self, env, gp):
+    def __init__(self, space, gp):
         """
         Initializer
-        :param env: the environment
+        :param space: the space the model lives in
         :param gp: the GP model, an instance of a subclass of edge.model.inference.GP. Should be initialized by
             a subclass
         """
-        super(GPModel, self).__init__(env)
+        super(GPModel, self).__init__(space)
         self.gp = gp
 
     def _query(self, x):

--- a/edge/model/safety_models/safety_truth.py
+++ b/edge/model/safety_models/safety_truth.py
@@ -12,15 +12,15 @@ class SafetyTruth(GroundTruth):
     Represents the ground truth about a safety measure. A realistic Agent typically does not have access to that,
     but instead to a SafetyMeasure model.
     """
-    def __init__(self, env):
+    def __init__(self, space):
         """
         Initializer
         This method DOES NOT initialize all parameters. You should use one of self.compute, self.load, or
         self.from_vibly_file to finalize the initialization
-        :param env: the environment
+        :param space: the environment
         """
         super(SafetyTruth, self).__init__()
-        self.env = env
+        self.space = space
 
         # These attributes are initialized either by compute, load, or from_vibly_file
         self.stateaction_space = None
@@ -254,7 +254,7 @@ class SafetyTruth(GroundTruth):
         This method is computationally intensive.
         :param Q_map_path: path to the dynamics map. If None, the dynamics map is computed beforehand.
         """
-        self.stateaction_space = self.env.stateaction_space
+        self.stateaction_space = self.space
 
         if Q_map_path is not None:
             Q_map = np.load(Q_map_path, allow_pickle=True)
@@ -335,7 +335,7 @@ class SafetyTruth(GroundTruth):
     @staticmethod
     def load(load_path, env):
         truth = SafetyTruth(env)
-        truth.stateaction_space = env.stateaction_space
+        truth.stateaction_space = space
 
         loaded = np.load(load_path)
 

--- a/edge/model/safety_models/safety_truth.py
+++ b/edge/model/safety_models/safety_truth.py
@@ -12,7 +12,7 @@ class SafetyTruth(GroundTruth):
     Represents the ground truth about a safety measure. A realistic Agent typically does not have access to that,
     but instead to a SafetyMeasure model.
     """
-    def __init__(self, space):
+    def __init__(self, env):
         """
         Initializer
         This method DOES NOT initialize all parameters. You should use one of self.compute, self.load, or
@@ -20,7 +20,7 @@ class SafetyTruth(GroundTruth):
         :param space: the environment
         """
         super(SafetyTruth, self).__init__()
-        self.space = space
+        self.env = env
 
         # These attributes are initialized either by compute, load, or from_vibly_file
         self.stateaction_space = None
@@ -254,7 +254,7 @@ class SafetyTruth(GroundTruth):
         This method is computationally intensive.
         :param Q_map_path: path to the dynamics map. If None, the dynamics map is computed beforehand.
         """
-        self.stateaction_space = self.space
+        self.stateaction_space = self.env.stateaction_space
 
         if Q_map_path is not None:
             Q_map = np.load(Q_map_path, allow_pickle=True)
@@ -335,7 +335,7 @@ class SafetyTruth(GroundTruth):
     @staticmethod
     def load(load_path, env):
         truth = SafetyTruth(env)
-        truth.stateaction_space = space
+        truth.stateaction_space = env.stateaction_space
 
         loaded = np.load(load_path)
 

--- a/edge/model/safety_models/safety_truth.py
+++ b/edge/model/safety_models/safety_truth.py
@@ -17,7 +17,7 @@ class SafetyTruth(GroundTruth):
         Initializer
         This method DOES NOT initialize all parameters. You should use one of self.compute, self.load, or
         self.from_vibly_file to finalize the initialization
-        :param space: the environment
+        :param env: the environment
         """
         super(SafetyTruth, self).__init__()
         self.env = env

--- a/edge/model/value_models/gpq_learning.py
+++ b/edge/model/value_models/gpq_learning.py
@@ -10,11 +10,11 @@ class GPQLearning(GPModel):
     """
     Models the Q-Function over a StateActionSpace as a MaternGP updated with a Q-Learning update.
     """
-    def __init__(self, env, step_size, discount_rate,
+    def __init__(self, space, step_size, discount_rate,
                  x_seed, y_seed, gp_params=None):
         """
         Initializer
-        :param env: the environment
+        :param space: the Q-space (state-action space) that the model lives in.
         :param step_size: the step size in the Q-Learning update
         :param discount_rate: the discount rate
         :param x_seed: the seed input of the GP. Typically a list of stateactions
@@ -25,7 +25,7 @@ class GPQLearning(GPModel):
             gp_params = {}
 
         gp = MaternGP(x_seed, y_seed, **gp_params)
-        super(GPQLearning, self).__init__(env, gp)
+        super(GPQLearning, self).__init__(space, gp)
         self.step_size = step_size
         self.discount_rate = discount_rate
 
@@ -45,7 +45,7 @@ class GPQLearning(GPModel):
         )
         q_value_update = current_value + q_value_step
 
-        stateaction = self.env.stateaction_space[state, action]
+        stateaction = self.space[state, action]
         self.gp = self.gp.append_data(stateaction, q_value_update)
 
     @property
@@ -60,7 +60,7 @@ class GPQLearning(GPModel):
         }
 
     @staticmethod
-    def load(load_folder, env, x_seed, y_seed):
+    def load(load_folder, space, x_seed, y_seed):
         """
         Loads the model and the GP saved by the GPModel.save method. Note that this method may fail if the save was
         made with an older version of the code.
@@ -75,7 +75,7 @@ class GPQLearning(GPModel):
         with open(model_load_path, 'r') as f:
             state_dict = json.load(f)
 
-        model = GPQLearning(env, x_seed=x_seed, y_seed=y_seed, **state_dict)
+        model = GPQLearning(space, x_seed=x_seed, y_seed=y_seed, **state_dict)
         model.gp = gp
 
         return model

--- a/edge/model/value_models/q_learning.py
+++ b/edge/model/value_models/q_learning.py
@@ -13,18 +13,18 @@ class QLearning(DiscreteModel):
     ARRAY_SAVE_NAME = 'q_values_map.npy'
     SAVE_NAME = 'model.json'
 
-    def __init__(self, env, step_size, discount_rate):
+    def __init__(self, space, step_size, discount_rate):
         """
         Initializer
-        :param env: the environment
+        :param space: the Q-space (state-action space) that the model lives in.
         :param step_size: the step size in the Q-Learning update
         :param discount_rate: the discount rate
         """
-        super(QLearning, self).__init__(env)
+        super(QLearning, self).__init__(space)
         self.step_size = step_size
         self.discount_rate = discount_rate
         self.q_values = np.zeros(
-            self.env.stateaction_space.index_shape,
+            self.space.index_shape,
             dtype=np.float
         )
 
@@ -38,8 +38,8 @@ class QLearning(DiscreteModel):
         :param failed: whether the agent has failed
         """
         sa_index = (
-            self.env.stateaction_space.state_space.get_index_of(state),
-            self.env.stateaction_space.action_space.get_index_of(action)
+            self.space.state_space.get_index_of(state),
+            self.space.action_space.get_index_of(action)
         )
 
         self.q_values[sa_index] = self[sa_index] + self.step_size * (
@@ -71,7 +71,7 @@ class QLearning(DiscreteModel):
         np.save(array_path, self.q_values)
 
     @staticmethod
-    def load(load_folder, env):
+    def load(load_folder, space):
         """
         Loads the model and the array saved by the QLearning.save method. Note that this method may fail if the save was
         made with an older version of the code.
@@ -86,7 +86,7 @@ class QLearning(DiscreteModel):
             state_dict = json.load(f)
         q_values = np.load(array_path)
 
-        model = QLearning(env, **state_dict)
+        model = QLearning(space, **state_dict)
         model.q_values = q_values
 
         return model

--- a/experiments/hovership_penalized/simulation.py
+++ b/experiments/hovership_penalized/simulation.py
@@ -82,7 +82,8 @@ class PenalizedSimulation(ModelLearningSimulation):
             load_path = self.local_models_path / model_name
         else:
             load_path = self.models_path / model_name
-        self.agent.value_model = GPQLearning.load(load_path, self.env,
+        self.agent.value_model = GPQLearning.load(load_path,
+                                                  self.env.staetaction_space,
                                                   self.x_seed, self.y_seed)
 
     def run(self):

--- a/experiments/slip_penalized/simulation.py
+++ b/experiments/slip_penalized/simulation.py
@@ -85,7 +85,8 @@ class PenalizedSimulation(ModelLearningSimulation):
             load_path = self.local_models_path / model_name
         else:
             load_path = self.models_path / model_name
-        self.agent.value_model = GPQLearning.load(load_path, self.env,
+        self.agent.value_model = GPQLearning.load(load_path,
+                                                  self.env.stateaction_space,
                                                   self.x_seed, self.y_seed)
 
     def run(self):

--- a/experiments/slip_safety/simulation.py
+++ b/experiments/slip_safety/simulation.py
@@ -96,7 +96,8 @@ class SafetySimulation(ModelLearningSimulation):
             load_path = self.local_models_path / model_name
         else:
             load_path = self.models_path / model_name
-        self.agent.value_model = SafetyMeasure.load(load_path, self.env,
+        self.agent.value_model = SafetyMeasure.load(load_path,
+                                                    self.env.stateaction_space,
                                                     self.x_seed, self.y_seed)
 
     def run_optim(self):

--- a/experiments/slip_value_and_safety/simulation.py
+++ b/experiments/slip_value_and_safety/simulation.py
@@ -129,8 +129,8 @@ class ValueAndSafetyLearningSimulation(ModelLearningSimulation):
         from edge.model.value_models import GPQLearning
         models_names = list(self.get_models_to_save().keys())
         loaders= {
-            'Q_model': lambda mpath: GPQLearning(mpath, self.env, self.q_x_seed, self.q_y_seed),
-            'safety_model': lambda mpath: MaternSafety(mpath, self.env, self.gamma_optimistic,
+            'Q_model': lambda mpath: GPQLearning(mpath, self.env.stateaction_space, self.q_x_seed, self.q_y_seed),
+            'safety_model': lambda mpath: MaternSafety(mpath, self.env.stateaction_space, self.gamma_optimistic,
                                                        self.s_x_seed, self.s_y_seed),
         }
         for mname in models_names:


### PR DESCRIPTION
Adjusted models to have `space` instead of `env`. Note, I called it space and not `stateaction_space` or `q_space`, since at the base level, a model can be in any space. This also keeps the name reasonably short :).

Note, I haven't changed the safety_truth, as that seems to also use `env.dynamics` and other things. I've made appropriate adjustments for the slip and hovership experiments, but not for gridworld and other things.